### PR TITLE
PD-129 added cases to handle filter and sort for json fields.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "source/Meadow-Filter.js",
   "scripts": {
     "coverage": "nyc npm run test && nyc report --reporter=lcov",
-    "test": "./node_modules/.bin/mocha --exit -u tdd -R spec"
+    "test": "mocha --ignore \"test/integration/*.js\" --exit -u tdd --recursive",
+    "test:integration": "mocha -u tdd --timeout 20000 --recursive test/integration/jsonFilterTest.js"
   },
   "repository": {
     "type": "git",
@@ -22,10 +23,13 @@
   },
   "homepage": "https://github.com/bigal-hl/meadow-filter",
   "devDependencies": {
-    "chai": "^4.3.6",
+    "chai": "^4.3.7",
     "fable": "^2.0.1",
     "mocha": "^9.2.2",
     "nyc": "^15.1.0",
     "sinon": "^13.0.1"
+  },
+  "dependencies": {
+    "@paviasystems/service_pieces": "^1.0.48"
   }
 }

--- a/source/Meadow-Filter-Parse.js
+++ b/source/Meadow-Filter-Parse.js
@@ -160,6 +160,21 @@ const addFilterStanzaToQuery = (pFilterStanza, pQuery) =>
 			}
 			break;
 
+    case 'FBJV': // Filter by JSON Value (left-side AND)
+      pQuery.addFilter(
+        `"${pFilterStanza.Field}"`,
+        pFilterStanza.Value,
+        getFilterComparisonOperator(pFilterStanza.Operator),
+        'AND',
+        'jsonFieldKey'
+      );
+      break;
+
+    case 'FSJF': // Filter Sort Field
+      const tmpSortDirection = pFilterStanza.Operator === 'DESC' ? 'Descending' : 'Ascending';
+      pQuery.addSort({ Column: `"${pFilterStanza.Field}"`, Direction: tmpSortDirection });
+      break;
+
 		default:
 			//console.log('Unparsable filter stanza.');
 			return false;

--- a/source/Meadow-Filter-Parse.js
+++ b/source/Meadow-Filter-Parse.js
@@ -165,7 +165,7 @@ const addFilterStanzaToQuery = (pFilterStanza, pQuery) =>
       const jsonField = pFilterStanza.Field.split(',')[0];
       const subFields = pFilterStanza.Field.split(',')[1];
       pQuery
-        .addFilter('', '1', `LENGTH(${jsonField}) >`)
+        .addFilter('', '1', `LENGTH(${jsonField}) >`, 'AND', 'jsonFieldLen')
         .addFilter(
           `JSON_EXTRACT(${jsonField}, '$.${subFields}')`,
           pFilterStanza.Value,
@@ -182,7 +182,7 @@ const addFilterStanzaToQuery = (pFilterStanza, pQuery) =>
       const jsonField = pFilterStanza.Field.split(',')[0];
       const subFields = pFilterStanza.Field.split(',')[1];
       pQuery
-        .addFilter('', '1', `LENGTH(${jsonField})>`)
+        .addFilter('', '1', `LENGTH(${jsonField}) >`, 'AND', 'jsonFieldLen')
         .setSort([{ Column: `${jsonField}->'$.${subFields}'`, Direction: tmpSortDirection }]);
       break;
       }

--- a/source/Meadow-Filter-Parse.js
+++ b/source/Meadow-Filter-Parse.js
@@ -162,8 +162,9 @@ const addFilterStanzaToQuery = (pFilterStanza, pQuery) =>
 
     case 'FBJV':// Filter by JSON Value (left-side AND)
       {
-      const jsonField = pFilterStanza.Field.split(',')[0];
-      const subFields = pFilterStanza.Field.split(',')[1];
+      const fields = pFilterStanza.Field.split(',', 2);
+      const jsonField =fields[0];
+      const subFields = fields[1];
       pQuery
         .addFilter('', '1', `LENGTH(${jsonField}) >`, 'AND', 'jsonFieldLen')
         .addFilter(
@@ -179,8 +180,9 @@ const addFilterStanzaToQuery = (pFilterStanza, pQuery) =>
     case 'FSJF':// Filter Sort Field
       {
       const tmpSortDirection = pFilterStanza.Operator === 'DESC' ? 'Descending' : 'Ascending';
-      const jsonField = pFilterStanza.Field.split(',')[0];
-      const subFields = pFilterStanza.Field.split(',')[1];
+      const fields = pFilterStanza.Field.split(',', 2);
+      const jsonField =fields[0];
+      const subFields = fields[1];
       pQuery
         .addFilter('', '1', `LENGTH(${jsonField}) >`, 'AND', 'jsonFieldLen')
         .setSort([{ Column: `${jsonField}->'$.${subFields}'`, Direction: tmpSortDirection }]);

--- a/source/Meadow-Filter-Parse.js
+++ b/source/Meadow-Filter-Parse.js
@@ -160,20 +160,32 @@ const addFilterStanzaToQuery = (pFilterStanza, pQuery) =>
 			}
 			break;
 
-    case 'FBJV': // Filter by JSON Value (left-side AND)
-      pQuery.addFilter(
-        `"${pFilterStanza.Field}"`,
-        pFilterStanza.Value,
-        getFilterComparisonOperator(pFilterStanza.Operator),
-        'AND',
-        'jsonFieldKey'
-      );
+    case 'FBJV':// Filter by JSON Value (left-side AND)
+      {
+      const jsonField = pFilterStanza.Field.split(',')[0];
+      const subFields = pFilterStanza.Field.split(',')[1];
+      pQuery
+        .addFilter('', '1', `LENGTH(${jsonField}) >`)
+        .addFilter(
+          `JSON_EXTRACT(${jsonField}, '$.${subFields}')`,
+          pFilterStanza.Value,
+          getFilterComparisonOperator(pFilterStanza.Operator),
+          'AND',
+          'jsonFieldParameter'
+        );
       break;
+      }
 
-    case 'FSJF': // Filter Sort Field
+    case 'FSJF':// Filter Sort Field
+      {
       const tmpSortDirection = pFilterStanza.Operator === 'DESC' ? 'Descending' : 'Ascending';
-      pQuery.addSort({ Column: `"${pFilterStanza.Field}"`, Direction: tmpSortDirection });
+      const jsonField = pFilterStanza.Field.split(',')[0];
+      const subFields = pFilterStanza.Field.split(',')[1];
+      pQuery
+        .addFilter('', '1', `LENGTH(${jsonField})>`)
+        .setSort([{ Column: `${jsonField}->'$.${subFields}'`, Direction: tmpSortDirection }]);
       break;
+      }
 
 		default:
 			//console.log('Unparsable filter stanza.');

--- a/source/Meadow-Filter-Parse.js
+++ b/source/Meadow-Filter-Parse.js
@@ -165,6 +165,8 @@ const addFilterStanzaToQuery = (pFilterStanza, pQuery) =>
       const fields = pFilterStanza.Field.split(',', 2);
       const jsonField =fields[0];
       const subFields = fields[1];
+      if (jsonField !== undefined && jsonField.trim() !== "" && subFields !== undefined && subFields.trim() !== "")
+        {
       pQuery
         .addFilter('', '1', `LENGTH(${jsonField}) >`, 'AND', 'jsonFieldLen')
         .addFilter(
@@ -174,6 +176,10 @@ const addFilterStanzaToQuery = (pFilterStanza, pQuery) =>
           'AND',
           'jsonFieldParameter'
         );
+      }
+      else{
+          throw new Error("Invalid Jsonfield or path");
+      }
       break;
       }
 
@@ -183,9 +189,15 @@ const addFilterStanzaToQuery = (pFilterStanza, pQuery) =>
       const fields = pFilterStanza.Field.split(',', 2);
       const jsonField =fields[0];
       const subFields = fields[1];
+      if (jsonField !== undefined && jsonField.trim() !== "" && subFields !== undefined && subFields.trim() !== "")
+        {
       pQuery
         .addFilter('', '1', `LENGTH(${jsonField}) >`, 'AND', 'jsonFieldLen')
         .setSort([{ Column: `${jsonField}->'$.${subFields}'`, Direction: tmpSortDirection }]);
+      }
+      else{
+          throw new Error("Invalid Jsonfield or path");
+      }
       break;
       }
 

--- a/test/integration/api-settings.js
+++ b/test/integration/api-settings.js
@@ -1,0 +1,6 @@
+module.exports = {
+	APIServerURL: process.env['HL_SERVER_URL'] || 'https://localhost/1.0/',
+	APIServerEnforceSSL: false,
+	UserName: process.env['HL_USER'] || '',
+	Password: process.env['HL_PASS'] || '',
+};

--- a/test/integration/client.js
+++ b/test/integration/client.js
@@ -1,0 +1,58 @@
+const got = require('got');
+const buildClient = (prefixUrl, cookieJar) => {
+	return got.extend({
+		prefixUrl,
+		cookieJar,
+		responseType: 'json',
+		https: {
+			rejectUnauthorized: false,
+		},
+		hooks: {
+			timeout: 15000,
+			beforeRequest: [
+				(options) => {
+					const postBody = `${
+						options.method === 'POST' ? `: ${JSON.stringify(options.json)}` : ''
+					}`;
+					console.info(
+						`Going to send ${options.method} to API on URL [${options.url}]${postBody}`
+					);
+				},
+			],
+			afterResponse:
+			[
+				async (response, retryWithMergedOptions) =>
+				{
+					if (response.body && response.body.Error)
+					{
+						throw new Error(response.body.Error);
+					}
+
+					if (response.body && response.body.ErrorCode)
+					{
+						throw new Error(`Error Code: ${response.body.ErrorCode}`);
+					}
+
+					const method = response.request.options.method;
+					const url = response.request.requestUrl;
+					console.info(`Successfully sent ${method} to API on URL [${url}]`);
+					return response;
+				},
+			],
+			beforeError: [
+				(error) => {
+					const request = error.request || { options: {} };
+					const method = request.options.method;
+					const url = request.requestUrl;
+					console.error(`Problem with ${method} to API on URL [${url}]`, {
+						Code: error.response && error.response.statusCode,
+						Error: error.response && error.response.body,
+					});
+					return error;
+				},
+			],
+		},
+	});
+};
+
+module.exports = { buildClient };

--- a/test/integration/jsonFilterTest.js
+++ b/test/integration/jsonFilterTest.js
@@ -1,0 +1,27 @@
+const chai = require('chai');
+const expect = chai.expect;
+const ToughCookie = require('tough-cookie');
+
+const apiSettings = require('./api-settings.js');
+const { buildClient } = require('./client.js');
+
+const apiUrl = apiSettings.APIServerURL;
+const cookieJar = new ToughCookie.CookieJar();
+const api = buildClient(apiUrl, cookieJar);
+
+suite('Method test', async () =>
+{
+  test('Check Sort', async () => {
+    // check: sort the filtered documents and then return the pagination results back: 0th matches 10th record
+		await api.post('Authenticate', { json: { UserName: apiSettings.UserName, Password: apiSettings.Password } });
+		const fbjvFilter = 'FBJV~FormDataJson,Header.SampleMaterial~EQ~Profile Testing';
+		const fsjfFilter = 'FSJF~FormDataJson,Header.SampleMaterial~DESC~0';
+
+		const firstTwentyQuery = `Documents/FilteredTo/${fbjvFilter}~${fsjfFilter}/0/20`;
+		const tenToTwentyQuery = `Documents/FilteredTo/${fbjvFilter}~${fsjfFilter}/10/10`;
+
+		const firstTwentyResult = await api.get(firstTwentyQuery);
+		const tenToTwentyResult = await api.get(tenToTwentyQuery);
+		expect(tenToTwentyResult.body[0]['IDDocument']).to.deep.equal(firstTwentyResult.body[10]['IDDocument']);
+	});
+});


### PR DESCRIPTION
Ticket: https://teamheadlight.atlassian.net/browse/PD-129
Approach: Try prototyping SQL queries with [Foxhound](https://github.com/stevenvelozo/foxhound). It works we need to add support to the meadow filter.
 ```
 var _Fable = require('fable').new();
 var libFoxHound = require('foxhound');
 
var tmpQuery = libFoxHound
.new(_Fable)
.setDialect('MySQL')
.setScope('Document')
.addFilter('length(FormDataJson)', '1', '>', 'AND', 'FormDataJson_length')
.addFilter("JSON_EXTRACT(FormDataJson, '$.Header.SampleMaterial')", 'Profile Testing', '=', 'AND','jsonFieldKey');

  console.log(tmpQuery.buildReadQuery().query.body);
  // ----
var tmpQuery = libFoxHound
 .new(_Fable)
 .setDialect('MySQL')
 .setScope('Document')
 .setDataElements(['IDDocument', 'CreateDate', 'FormDataJson', "FormDataJson->'$.Header.SampleMaterial'"])
 .addFilter('length(FormDataJson)', '1', '>', 'AND', 'FormDataJson_length')
 .setSort([{ Column: "FormDataJson->'$.Header.SampleMaterial'", Direction: 'Descending' }]);

console.log(tmpQuery.buildReadQuery().query.body);
```
generates:
```
   SELECT `IDDocument`, `CreateDate`, `FormDataJson` FROM `Document` WHERE length(FormDataJson) > :FormDataJson_length_w0 AND JSON_EXTRACT(FormDataJson, '$.Header.SampleMaterial') = :jsonFieldKey_w1;
   ---
   SELECT `IDDocument`, `CreateDate`, `FormDataJson`, `FormDataJson->'$`.`Header` FROM `Document` WHERE length(FormDataJson) > :FormDataJson_length_w0 ORDER BY FormDataJson->'$.Header.SampleMaterial' DESC;
```
After which added the case stmts to support new filter and sort operations in json fields.

--
New changes:

https://localhost/1.0/Documents/FilteredTo/FSJF~FormDataJson,Header.SampleMaterial~DESC~0
```
SELECT `Document`.* 
FROM `Document` 
WHERE  LENGTH(FormDataJson) > "1" AND 
`Document`.Deleted = 0 
ORDER BY FormDataJson->'$.Header.SampleMaterial' DESC, DocumentDate DESC LIMIT 250;
```
https://localhost/1.0/Documents/FilteredTo/FBJV~FormDataJson,Header.SampleMaterial~EQ~Profile Testing
```
SELECT `Document`.* 
FROM `Document` 
WHERE  LENGTH(FormDataJson) > "1" AND 
JSON_EXTRACT(FormDataJson, '$.Header.SampleMaterial') = "Profile Testing" AND  
`Document`.Deleted = 0 
ORDER BY DocumentDate DESC LIMIT 250;
```
Steps: 
to repro locally, 

1. copy the latest changes of this repo to mpi_api `node_modules`
   `cp -r /Pavia/meadow-filter/source/* /Pavia/mpi_api/node_modules/meadow-filter/source`
2. and touch any file in mpi_api may be`/Pavia/mpi_api/ts_source/bundles/contentmanagement/Documents.ts`, so that changes are picked up by the watcher.
3. check query in docker logs
   `docker logs pavia-headlight-api-1 -n 100 --follow`
   
 Tests:
  check: sort the filtered documents and then return the pagination results back: `0th matches 10th record`
 ```
https://localhost/1.0/Documents/FilteredTo/FBJV~FormDataJson,Header.SampleMaterial~EQ~Profile Testing~FSJF~FormDataJson,Header.SampleMaterial~DESC~0/10/10
https://localhost/1.0/Documents/FilteredTo/FBJV~FormDataJson,Header.SampleMaterial~EQ~Profile Testing~FSJF~FormDataJson,Header.SampleMaterial~DESC~0/0/20
 ```
 