### PR TITLE
parse: default to 40-digit precision

### DIFF
--- a/source/Meadow-Filter-Parse.js
+++ b/source/Meadow-Filter-Parse.js
@@ -148,8 +148,8 @@ const getDataType = (encodedType) =>
 			type = 'UNSIGNED';
 			break;
 		case 'DD':
-			// base 10, 5 decimal places (should cover 99% of use cases)
-			type = 'DECIMAL(10,5)';
+			// precision 40 digits, 5 decimal places (should cover 99% of use cases)
+			type = 'DECIMAL(40,5)';
 			break;
 		case 'DATE':
 			type = 'DATE';

--- a/test/test.js
+++ b/test/test.js
@@ -274,7 +274,7 @@ suite('Filter Stanza Parse', () =>
         [
             { requestedType: 'UINT', expectedType: 'UNSIGNED'},
             { requestedType: 'SINT', expectedType: 'SIGNED'},
-            { requestedType: 'DD', expectedType: 'DECIMAL(10,5)'},
+            { requestedType: 'DD', expectedType: 'DECIMAL(40,5)'},
             { requestedType: 'DATE', expectedType: 'DATE'},
         ];
         fsjfByNumberTests.forEach((input) =>


### PR DESCRIPTION
 * note if no precision specified, it defaults to 10
 * note that quotes in a string count as one precision in the number
 * hitting use cases where the number is 10 digits, but it goes over because of the quotes around it