### PR TITLE
PD-1169: fix FBJV LK and FBJVOR

### DIFF
--- a/source/Meadow-Filter-Parse.js
+++ b/source/Meadow-Filter-Parse.js
@@ -210,7 +210,8 @@ const parseJSONFieldAndPath = (pFilterStanza) =>
  */
 const addFilterJSONToQuery = (fieldColumn, jsonPath, value, comparisonOperator, connector, pQuery) =>
 {
-	pQuery.addFilter('', '', '(');
+	// honor the connector by placing it before the complex clause
+	pQuery.addFilter('', '', '(', connector);
 	// TODO: prefix 'fieldColumn' with table name to avoid ambiguity (e.g. in joins)
 	pQuery.addFilter(`JSON_VALID(${fieldColumn})`, 1, '=', 'AND', 'validJson');
 	let command = `CAST(JSON_UNQUOTE(JSON_EXTRACT(${fieldColumn}, '$${jsonPath}')) AS CHAR)`;
@@ -234,7 +235,7 @@ const addFilterJSONToQuery = (fieldColumn, jsonPath, value, comparisonOperator, 
 		// value is a number, extract it from the strings
 		finalValue = Number(value);
 	}
-	pQuery.addFilter(command, finalValue, comparisonOperator, connector, 'jsonExtracted');
+	pQuery.addFilter(command, finalValue, comparisonOperator, 'AND', 'jsonExtracted');
 	pQuery.addFilter('', '', ')');
 	// to follow foxhound query builder chaining
 	return pQuery;

--- a/source/Meadow-Filter-Parse.js
+++ b/source/Meadow-Filter-Parse.js
@@ -213,7 +213,7 @@ const addFilterJSONToQuery = (fieldColumn, jsonPath, value, comparisonOperator, 
 	pQuery.addFilter('', '', '(');
 	// TODO: prefix 'fieldColumn' with table name to avoid ambiguity (e.g. in joins)
 	pQuery.addFilter(`JSON_VALID(${fieldColumn})`, 1, '=', 'AND', 'validJson');
-	let command = `JSON_UNQUOTE(JSON_EXTRACT(${fieldColumn}, '$${jsonPath}'))`;
+	let command = `CAST(JSON_UNQUOTE(JSON_EXTRACT(${fieldColumn}, '$${jsonPath}')) AS CHAR)`;
 	// finalValue will be the value to use in the filter
 	let finalValue = value;
 	// determine the finalValue based on the expected data type of the input. Distinguish between string and number.

--- a/test/test.js
+++ b/test/test.js
@@ -174,9 +174,9 @@ suite('Filter Stanza Parse', () =>
         {
             // given
             const filterString = 'FBJVOR~FormData.IDWaffle~GT~123';
-            queryMock.expects('addFilter').once().withArgs('','','(');
+            queryMock.expects('addFilter').once().withArgs('','','(', 'OR');
             queryMock.expects('addFilter').once().withArgs('JSON_VALID(FormData)', 1, '=', 'AND');
-            queryMock.expects('addFilter').once().withArgs('CAST(JSON_UNQUOTE(JSON_EXTRACT(FormData, \'$.IDWaffle\')) AS CHAR)', 123, '>', 'OR');
+            queryMock.expects('addFilter').once().withArgs('CAST(JSON_UNQUOTE(JSON_EXTRACT(FormData, \'$.IDWaffle\')) AS CHAR)', 123, '>', 'AND');
             queryMock.expects('addFilter').once().withArgs('','',')');
 
             // when
@@ -227,9 +227,9 @@ suite('Filter Stanza Parse', () =>
             queryMock.expects('addFilter').once().withArgs('Limit', '0', '<', 'OR');
             queryMock.expects('addFilter').once().withArgs('', '', ')');
             //// calls around json fields
-            queryMock.expects('addFilter').once().withArgs('', '', '(');
+            queryMock.expects('addFilter').once().withArgs('', '', '(', 'OR');
             queryMock.expects('addFilter').once().withArgs('JSON_VALID(SomeField)', 1, '=', 'AND');
-            queryMock.expects('addFilter').once().withArgs('CAST(JSON_UNQUOTE(JSON_EXTRACT(SomeField, \'$.IDWaffle\')) AS CHAR)', [ 1, 23 ,456 ], 'IN', 'OR');
+            queryMock.expects('addFilter').once().withArgs('CAST(JSON_UNQUOTE(JSON_EXTRACT(SomeField, \'$.IDWaffle\')) AS CHAR)', [ 1, 23 ,456 ], 'IN', 'AND');
             queryMock.expects('addFilter').once().withArgs('', '', ')');
 
             // when

--- a/test/test.js
+++ b/test/test.js
@@ -144,7 +144,7 @@ suite('Filter Stanza Parse', () =>
             queryMock.expects('addFilter').once().withArgs('','','(');
             queryMock.expects('addFilter').once().withArgs('JSON_VALID(FormData)', 1, '=', 'AND');
             //// make sure quotes are escaped to avoid command injections
-            queryMock.expects('addFilter').once().withArgs('JSON_UNQUOTE(JSON_EXTRACT(FormData, \'$.IDWaffle\\\')) AND Select COUNT(*) From Document AND ((\\\'1\'))', 123, '=', 'AND');
+            queryMock.expects('addFilter').once().withArgs('CAST(JSON_UNQUOTE(JSON_EXTRACT(FormData, \'$.IDWaffle\\\')) AND Select COUNT(*) From Document AND ((\\\'1\')) AS CHAR)', 123, '=', 'AND');
             queryMock.expects('addFilter').once().withArgs('','',')');
 
             // when
@@ -160,7 +160,7 @@ suite('Filter Stanza Parse', () =>
             const filterString = 'FBJV~FormData.IDWaffle~EQ~123';
             queryMock.expects('addFilter').once().withArgs('','','(');
             queryMock.expects('addFilter').once().withArgs('JSON_VALID(FormData)', 1, '=', 'AND');
-            queryMock.expects('addFilter').once().withArgs('JSON_UNQUOTE(JSON_EXTRACT(FormData, \'$.IDWaffle\'))', 123, '=', 'AND');
+            queryMock.expects('addFilter').once().withArgs('CAST(JSON_UNQUOTE(JSON_EXTRACT(FormData, \'$.IDWaffle\')) AS CHAR)', 123, '=', 'AND');
             queryMock.expects('addFilter').once().withArgs('','',')');
 
             // when
@@ -176,7 +176,7 @@ suite('Filter Stanza Parse', () =>
             const filterString = 'FBJVOR~FormData.IDWaffle~GT~123';
             queryMock.expects('addFilter').once().withArgs('','','(');
             queryMock.expects('addFilter').once().withArgs('JSON_VALID(FormData)', 1, '=', 'AND');
-            queryMock.expects('addFilter').once().withArgs('JSON_UNQUOTE(JSON_EXTRACT(FormData, \'$.IDWaffle\'))', 123, '>', 'OR');
+            queryMock.expects('addFilter').once().withArgs('CAST(JSON_UNQUOTE(JSON_EXTRACT(FormData, \'$.IDWaffle\')) AS CHAR)', 123, '>', 'OR');
             queryMock.expects('addFilter').once().withArgs('','',')');
 
             // when
@@ -192,7 +192,7 @@ suite('Filter Stanza Parse', () =>
             const filterString = 'FBJL~SomeField.IDWaffle~INN~1,23,456';
             queryMock.expects('addFilter').once().withArgs('','','(');
             queryMock.expects('addFilter').once().withArgs('JSON_VALID(SomeField)', 1, '=', 'AND');
-            queryMock.expects('addFilter').once().withArgs('JSON_UNQUOTE(JSON_EXTRACT(SomeField, \'$.IDWaffle\'))', [ 1, 23, 456 ], 'IN', 'AND');
+            queryMock.expects('addFilter').once().withArgs('CAST(JSON_UNQUOTE(JSON_EXTRACT(SomeField, \'$.IDWaffle\')) AS CHAR)', [ 1, 23, 456 ], 'IN', 'AND');
             queryMock.expects('addFilter').once().withArgs('','',')');
             // when
             parse(filterString, queryStub);
@@ -207,7 +207,7 @@ suite('Filter Stanza Parse', () =>
             const filterString = 'FBJL~SomeField.IDWaffle~NIN~1,23,456';
             queryMock.expects('addFilter').once().withArgs('','','(');
             queryMock.expects('addFilter').once().withArgs('JSON_VALID(SomeField)', 1, '=', 'AND');
-            queryMock.expects('addFilter').once().withArgs('JSON_UNQUOTE(JSON_EXTRACT(SomeField, \'$.IDWaffle\'))', [ 1, 23, 456 ], 'NOT IN', 'AND');
+            queryMock.expects('addFilter').once().withArgs('CAST(JSON_UNQUOTE(JSON_EXTRACT(SomeField, \'$.IDWaffle\')) AS CHAR)', [ 1, 23, 456 ], 'NOT IN', 'AND');
             queryMock.expects('addFilter').once().withArgs('','',')');
 
             // when
@@ -229,7 +229,7 @@ suite('Filter Stanza Parse', () =>
             //// calls around json fields
             queryMock.expects('addFilter').once().withArgs('', '', '(');
             queryMock.expects('addFilter').once().withArgs('JSON_VALID(SomeField)', 1, '=', 'AND');
-            queryMock.expects('addFilter').once().withArgs('JSON_UNQUOTE(JSON_EXTRACT(SomeField, \'$.IDWaffle\'))', [ 1, 23 ,456 ], 'IN', 'OR');
+            queryMock.expects('addFilter').once().withArgs('CAST(JSON_UNQUOTE(JSON_EXTRACT(SomeField, \'$.IDWaffle\')) AS CHAR)', [ 1, 23 ,456 ], 'IN', 'OR');
             queryMock.expects('addFilter').once().withArgs('', '', ')');
 
             // when
@@ -283,7 +283,7 @@ suite('Filter Stanza Parse', () =>
             {
                 // given
                 const filterString = `FSJF~FormData.Meta.JCSequenceNumber~ASC~${input.requestedType}`;
-            queryMock.expects('addFilter').once().withArgs('JSON_VALID(FormData)', 1, '=', 'AND');
+                queryMock.expects('addFilter').once().withArgs('JSON_VALID(FormData)', 1, '=', 'AND');
                 queryMock.expects('addSort').once().withArgs({ Column: `CAST(FormData ->> \'$.Meta.JCSequenceNumber\' AS ${input.expectedType})`, Direction: 'Ascending'});
 
                 // when


### PR DESCRIPTION
 * [PD-1169](https://teamheadlight.atlassian.net/jira/software/c/projects/PD/issues/PD-1169)
 * FBJV LK: casting all FBJV requests to CHAR is honoring the default COLLATION for the column -> `utf8mb4_unicode_ci`
 * FBJVOR: the compound clauses that gets created for JSON filtering was not being correctly OR-ed to the rest of the where clauses