### PR TITLE
Fixing bug where fields could be prefixed with table name. 

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -155,24 +155,33 @@ suite('Filter Stanza Parse', () =>
             queryMock.verify();
         });
 
-        test('Filter by JSON Value - Fully qualified name with join', () =>
+        test('Filter by JSON Value - Json path fully qualified name with join', () =>
         {
             // given
-            const filterString = 'FBJV~Document.FormData.IDWaffle~EQ~123';
+            const filterString = 'FBJV~Document.FormData$.IDWaffle~EQ~123';
             queryMock.expects('addFilter').once().withArgs('','','(');
             queryMock.expects('addFilter').once().withArgs('JSON_VALID(Document.FormData)', 1, '=', 'AND');
             queryMock.expects('addFilter').once().withArgs('CAST(JSON_UNQUOTE(JSON_EXTRACT(Document.FormData, \'$.IDWaffle\')) AS CHAR)', 123, '=', 'AND');
             queryMock.expects('addFilter').once().withArgs('','',')');
 
             // when
-            parse(filterString, {
-                ...queryStub,
-                parameters: {
-                    join: [{
-                        Table: 'Document',
-                    }]
-                }
-            });
+            parse(filterString, queryStub);
+
+            // then
+            queryMock.verify();
+        });
+
+        test('Filter by JSON Value - Json path array selector', () =>
+        {
+            // given
+            const filterString = 'FBJV~FormData$[0]~EQ~123';
+            queryMock.expects('addFilter').once().withArgs('','','(');
+            queryMock.expects('addFilter').once().withArgs('JSON_VALID(FormData)', 1, '=', 'AND');
+            queryMock.expects('addFilter').once().withArgs('CAST(JSON_UNQUOTE(JSON_EXTRACT(FormData, \'$[0]\')) AS CHAR)', 123, '=', 'AND');
+            queryMock.expects('addFilter').once().withArgs('','',')');
+
+            // when
+            parse(filterString, queryStub);
 
             // then
             queryMock.verify();

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ const assert = chai.assert;
 suite('Filter Stanza Parse', () =>
 {
     const parse = require('../source/Meadow-Filter').parse;
-    let queryStub = { addFilter: () => { }, setDistinct: () => { }, addSort: () => { }, parameters: { join: [] } };
+    let queryStub = { addFilter: () => { }, setDistinct: () => { }, addSort: () => { } };
     let queryMock;
 
     setup(() =>


### PR DESCRIPTION
If a join is present with that table name look to find table name qualifiers on the field.


This is a fix for the following example query where the field name is qualified by the table name:

`/Documents/FilteredTo/FBJL~Project.CustomProperties.parish~INN~01/0/10?Joins=Project,IDProject,IDProject`

Normally this qualification isnt an issue but because JSON fields extract the sub-path it incorrectly extracts it.