### PR TITLE
Updating dd sort on json to include more precision on left hand side.

### DIFF
--- a/source/Meadow-Filter-Parse.js
+++ b/source/Meadow-Filter-Parse.js
@@ -148,8 +148,8 @@ const getDataType = (encodedType) =>
 			type = 'UNSIGNED';
 			break;
 		case 'DD':
-			// base 10, 5 decimal places (should cover 99% of use cases)
-			type = 'DECIMAL(10,5)';
+			// base 19,6 decimal places (should cover 99% of use cases)
+			type = 'DECIMAL(19,6)';
 			break;
 		case 'DATE':
 			type = 'DATE';

--- a/test/test.js
+++ b/test/test.js
@@ -307,7 +307,7 @@ suite('Filter Stanza Parse', () =>
         [
             { requestedType: 'UINT', expectedType: 'UNSIGNED'},
             { requestedType: 'SINT', expectedType: 'SIGNED'},
-            { requestedType: 'DD', expectedType: 'DECIMAL(10,5)'},
+            { requestedType: 'DD', expectedType: 'DECIMAL(19,6)'},
             { requestedType: 'DATE', expectedType: 'DATE'},
         ];
         fsjfByNumberTests.forEach((input) =>


### PR DESCRIPTION
This low level of precision is cutting off anything higher than 99999 which seems crazy low

Observe with this query (**sample values taken from real data on prod which im trying to consume**):

```sql
CREATE TEMPORARY TABLE JsonDemo (content VARCHAR(50) );
insert into JsonDemo
values  (241821961260.000000),
        (12050160010.000000),
        (18339251.200000),
        (8876750.000000),
        (990814.370000),
        (92885.520000),
        (1214.060000),
        (600.000000),
        (62.000000),
        (0.000000);

select CAST(content as DECIMAL(10, 5))
from JsonDemo
order by CAST(content as DECIMAL(10, 5)) desc;
```

Reading some docs it seems like we can make some minor modifications and not jump to crazy high https://dev.mysql.com/doc/refman/8.0/en/precision-math-decimal-characteristics.html

I chose 19,6 because it seems optimal for our use case and hits the upper bounds of their specified ranges (see docs) to maximize bytes: 

```
leftside: 19-6 = 13 digits = 6 bytes 
rightside: 6 = 3 bytes   ----- same bytes as before but i just went to 6 from 5 cause its the same number of bytes ¯\_(ツ)_/¯  
```

That will handle all values in the trillions, cant imagine we would ever go above that.